### PR TITLE
Cleanup spectrogram and wave

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.2
+current_version = 0.3.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,6 @@ setup(
     setup_requires=["pytest-runner"],
     test_suite="tests",
     url="https://github.com/lxkain/signalworks",
-    version="0.2.2",
+    version="0.3.0",
     zip_safe=False,
 )

--- a/signalworks/__init__.py
+++ b/signalworks/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """Alexander Kain"""
 __email__ = "lxkain@gmail.com"
-__version__ = "0.2.2"
+__version__ = "0.3.0"

--- a/signalworks/dsp.py
+++ b/signalworks/dsp.py
@@ -177,7 +177,7 @@ def spectrogram(
     wav: Wave,
     frame_size: float,
     frame_rate: float,
-    window: Callable[[np.ndarray], np.ndarray] = signal.hann,
+    window: Callable[[int], np.ndarray] = signal.hann,
     NFFT: Optional[int] = None,
     normalized: bool = False,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
@@ -200,39 +200,105 @@ def spectrogram(
 
 def spectrogram_centered(
     wav: Wave,
-    frame_size: float,
+    frame_period: float,
     time: np.ndarray,
-    window: Callable[[np.ndarray], np.ndarray] = signal.hann,
+    window: Callable[[int], np.ndarray] = signal.hann,
     NFFT: Optional[int] = None,
-    normalized: bool = False,
+    normalize_signal: bool = False,
+    normalize_output: bool = False,
     pre_emphasis: Optional[float] = None,
+    channel: int = 0,
+    channel_aggregate: Optional[Callable[[np.ndarray], np.ndarray]] = None,
 ) -> Tuple[np.ndarray, np.ndarray]:
-    """return log-magnitude spectrogram in dB"""
+    """return log-magnitude spectrogram in dB
 
-    s = wav.value / np.abs(
-        np.max(wav.value)
-    )  # make float by normalizing and later clipping is more uniform
-    assert s.max() == 1
+    Parameters
+    ----------
+    wav : Wave
+        Wave object that contains the information you want to determine the
+        log-magnitude spectrogram of
+    frame_period : float
+        The length of the frame in seconds
+    time : np.ndarray
+        A numpy array representing the time values (in samples, not seconds) of
+        where you want frames centered about, typically evenly spaced over a range
+    window : Callable[[int], np.ndarray], optional
+        The Windowing function to apply to each frame
+        Possible pre-made functions are shown in scipy.signal.windows
+        by default signal.hann
+    NFFT : Optional[int], optional
+        Number of FFT points to use when for the rfft calculation
+        If None, the NFFT is computed based on the number of samples on each frame
+        It is suggested that this value be a power of 2
+        by default None
+    normalize_signal : bool, optional
+        scales the signal so that it ranges between -1 and 1
+        by default False
+    normalize_output : bool, optional
+        Adjusts the value of the spectrogram so that it's between 0 and 1
+        by default False
+    pre_emphasis : Optional[float], optional
+        if a value is provided, it is a constant to apply for a pre-emphasis
+        filter where x´[t] = x[t] - α * x[t-1] where α is the pre-emphasis value
+        values 0.0 <= α <= 1.0,
+        by default None
+    channel : int
+        Specifies which channel in the Wave object to use
+
+        The value here is ignored if a channel_aggregate method is provided,
+        or if Wave track has only one channel
+        by default 0
+    channel_aggregate : Optional[Callable[[np.ndarray], np.ndarray]], optional
+        If the Wave track has multiple channels, use this method to aggregate
+        the channels together.  A typical usecase would be to pass np.average;
+        atlernate use-cases may be np.maximum or np.minimum. The callable method
+        must support the passing of an axis argument.
+
+        This method will supersede the channel argument, but it is ignored if
+        Wave object has only one channel
+        by default None
+
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray]
+        Spectrogram matrix and a corresponding array of frequency values
+    """
+
+    # When dealing with multi-channel audio
+    if wav.value.ndim > 1:
+        # if an aggregation method is provided, use that to squash data together
+        if channel_aggregate is not None:
+            s = channel_aggregate(wav.value, axis=0).astype(float)  # type: ignore
+
+        # if no aggregation method is provided, and no channel is provided, grab the first channel
+        else:
+            s = wav.value[:, channel].astype(float)
+
+    if normalize_signal:
+        s = wav.value / np.abs(
+            np.max(wav.value)
+        )  # make float by normalizing and later clipping is more uniform
 
     if pre_emphasis is not None:
-        if pre_emphasis < 0.0 or pre_emphasis > 1.0:
-            logger.warning(
-                f"Pre-Emphasis Filter Value of {pre_emphasis} is outside of 0-1 range, ignoring."
-            )
-        else:
-            s -= pre_emphasis * np.roll(s, -1)
-    ftr = frame_centered(s, time, int(round(frame_size * wav.fs)))
-    assert ftr.dtype == np.float
-    ftr *= window(ftr.shape[1])
+        s -= pre_emphasis * np.roll(s, -1)
+
+    ftr = frame_centered(s, time, int(round(frame_period * wav.fs)))
+
     if NFFT is None:
-        NFFT = 2 ** nextpow2(ftr.shape[1])
-    M = np.abs(rfft(ftr, NFFT))
-    np.clip(M, 1e-16, None, out=M)
+        NFFT = 2 ** ftr.shape[1].bit_length()
+
+    ftr *= window(ftr.shape[1])
+    M = np.absolute(rfft(ftr, n=NFFT))
+    np.clip(M, np.finfo(M.dtype).eps, None, out=M)
+
     M[:] = np.log10(M) * 20
-    if normalized:
+    # faster than np.linspace
+    frequency = np.arange(M.shape[1]) / M.shape[1] * wav.fs / 2
+
+    if normalize_output:
         M[:] = (M.T - np.min(M, axis=1)).T
         M[:] = (M.T / np.max(M, axis=1)).T
-    frequency = np.arange(M.shape[1]) / M.shape[1] * wav.fs / 2
+
     return M, frequency
 
 

--- a/signalworks/tracking/__init__.py
+++ b/signalworks/tracking/__init__.py
@@ -51,16 +51,16 @@ def load_audio(
             raise MultiChannelError(
                 f"cannot select channel {channel} from monaural file {path}"
             )
-        multiTrack[channel_names[0]] = Wave(value, fs, path=str(path))
+        multiTrack[channel_names[0]] = Wave(value, fs, path=path)
     if value.ndim == 2:
 
         if channel is None:
-            multiTrack[channel_names[0]] = Wave(value[:, 0], fs, path=str(path))
-            multiTrack[channel_names[1]] = Wave(value[:, 1], fs, path=str(path))
+            multiTrack[channel_names[0]] = Wave(value[:, 0], fs, path=path)
+            multiTrack[channel_names[1]] = Wave(value[:, 1], fs, path=path)
         else:
             try:
                 multiTrack[channel_names[channel]] = Wave(
-                    value[:, channel], fs, path=str(path)
+                    value[:, channel], fs, path=path
                 )
             except IndexError:
                 raise MultiChannelError(
@@ -71,18 +71,12 @@ def load_audio(
     for k in multiTrack.keys():
         value = multiTrack[k].value
 
-        if value.dtype == np.dtype(np.int16):
-            multiTrack[k].min = -32767
-            multiTrack[k].max = 32768
-        elif value.dtype == np.dtype(np.int32):
-            multiTrack[k].min = -2147483648
-            multiTrack[k].max = 2147483647
-        elif value.dtype == np.dtype(np.uint8):
-            multiTrack[k].min = 0
-            multiTrack[k].max = 255
-        elif value.dtype in set([np.dtype(np.float64), np.dtype(np.float32)]):
-            multiTrack[k].max = 1.0
+        if np.issubdtype(value.dtype, np.integer):
+            multiTrack[k].min = np.iinfo(value.dtype).min
+            multiTrack[k].max = np.iinfo(value.dtype).max
+        elif np.issubdtype(value.dtype, np.floating):
             multiTrack[k].min = -1.0
+            multiTrack[k].max = 1.0
         else:
             logging.error(f"Wave dtype {value.dtype} not supported")
             raise NotImplementedError

--- a/signalworks/tracking/wave.py
+++ b/signalworks/tracking/wave.py
@@ -1,16 +1,15 @@
 import logging
 import os
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional
 
-import numpy
+import numpy as np
 from scipy.io.wavfile import read as wav_read
 from scipy.io.wavfile import write as wav_write
 from scipy.signal import resample_poly
-from signalworks.tracking.error import MultiChannelError
 from signalworks.tracking.tracking import Track
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
@@ -21,20 +20,27 @@ class Wave(Track):
 
     def __init__(
         self,
-        value: numpy.ndarray,
+        value: np.ndarray,
         fs: int,
-        duration: int = None,
+        duration: Optional[int] = None,
         offset: int = 0,
-        path: Union[str, Path] = None,
+        path: Optional[Path] = None,
     ) -> None:
         super().__init__(path)
+
         if path is None:
-            path = str(id(self))
-        self.min = None
-        self.max = None
-        # TODO: what happens if path is None
-        self.path = Path(path).with_suffix(self.default_suffix)
-        assert isinstance(value, numpy.ndarray)
+            self.path = (Path.home() / str(id)).with_suffix(self.default_suffix)
+        else:
+            self.path = Path(path).with_suffix(self.default_suffix)
+
+        if np.issubdtype(value.dtype, np.integer):
+            self.min = np.iinfo(value.dtype).min
+            self.max = np.iinfo(value.dtype).max
+        elif np.issubdtype(value.dtype, np.floating):
+            self.min = -1.0
+            self.max = 1.0
+
+        assert isinstance(value, np.ndarray)
         assert 1 <= value.ndim, "only a single channel is supported"
         assert isinstance(fs, int)
         assert fs > 0
@@ -43,9 +49,9 @@ class Wave(Track):
         self._offset = (
             offset
         )  # this is required to support heterogenous fs in multitracks
-        self.type: Optional[str] = "Wave"
-        self.label: Optional[str] = f"amplitude-{value.dtype}"
-        if not duration:
+        self.type = "Wave"
+        self.label = f"amplitude-{value.dtype}"
+        if duration is None:
             duration = len(self._value)
         assert len(self._value) <= duration < len(self._value) + 1, (
             "Cannot set duration of a wave to other than a number in "
@@ -64,9 +70,9 @@ class Wave(Track):
 
     def get_time(self):
         return (
-            numpy.arange(len(self._value))
+            np.arange(len(self._value))
             if self._offset == 0
-            else numpy.arange(len(self._value)) + self._offset
+            else np.arange(len(self._value)) + self._offset
         )
 
     def set_time(self, time):
@@ -78,7 +84,7 @@ class Wave(Track):
         return self._value
 
     def set_value(self, value):
-        assert isinstance(value, numpy.ndarray)
+        assert isinstance(value, np.ndarray)
         assert 1 == value.ndim, "only a single channel is supported"
         self._value = value
         if not (len(self._value) <= self._duration < len(self._value) + 1):
@@ -122,15 +128,7 @@ class Wave(Track):
     dtype = property(get_dtype)
 
     def get_bitdepth(self):
-        dtype = self._value.dtype
-        if dtype == numpy.int16:
-            return 16
-        elif dtype == numpy.float32 or dtype == numpy.int32:
-            return 32
-        elif dtype == numpy.float64:
-            return 64
-        else:
-            raise Exception("unknown dtype = %s" % dtype)
+        return self._value.dtype.itemsize * 8
 
     bitdepth = property(get_bitdepth)
 
@@ -148,7 +146,7 @@ class Wave(Track):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "\n".join(
             [
                 f"value={self.value}",
@@ -160,6 +158,9 @@ class Wave(Track):
             ]
         )
 
+    def __repr__(self) -> str:
+        return str(self)
+
     def __len__(self):
         return len(self._value)
 
@@ -167,12 +168,16 @@ class Wave(Track):
         assert type(other) == type(self), "Cannot add Track objects of different types"
         assert self._fs == other._fs, "sampling frequencies must match"
         assert self.value.dtype == other.value.dtype, "dtypes must match"
-        value = numpy.concatenate((self._value, other._value))
+        value = np.concatenate((self._value, other._value))
         return type(self)(value, self.fs)
 
-    def resample(self, fs):
+    def resample(self, fs: int) -> "Wave":
         """resample to a certain fs"""
-        assert isinstance(fs, int)
+
+        if not isinstance(fs, int):
+            logger.error("Resample only supporters integers, ignoring")
+            return self
+
         if fs != self._fs:
             if fs > self._fs:  # upsampling
                 return type(self)(resample_poly(self._value, int(fs / self._fs), 1), fs)
@@ -185,35 +190,35 @@ class Wave(Track):
         """
         return a link (if unchanged) or copy of signal in the specified dtype (often changes bit-depth as well)
         """
-        assert isinstance(source, numpy.ndarray)
+        assert isinstance(source, np.ndarray)
         source_dtype = source.dtype
         assert source_dtype in (
-            numpy.int16,
-            numpy.int32,
-            numpy.float32,
-            numpy.float64,
+            np.int16,
+            np.int32,
+            np.float32,
+            np.float64,
         ), "source must be a supported type"
         assert target_dtype in (
-            numpy.int16,
-            numpy.int32,
-            numpy.float32,
-            numpy.float64,
+            np.int16,
+            np.int32,
+            np.float32,
+            np.float64,
         ), "target must be a supported type"
         if source_dtype == target_dtype:
             return source
         else:  # conversion
-            if source_dtype == numpy.int16:
-                if target_dtype == numpy.int32:
+            if source_dtype == np.int16:
+                if target_dtype == np.int32:
                     return source.astype(target_dtype) << 16
-                else:  # target_dtype == numpy.float32 / numpy.float64:
+                else:  # target_dtype == np.float32 / np.float64:
                     return source.astype(target_dtype) / (1 << 15)
-            elif source_dtype == numpy.int32:
-                if target_dtype == numpy.int16:
+            elif source_dtype == np.int32:
+                if target_dtype == np.int16:
                     return (source >> 16).astype(target_dtype)  # lossy
-                else:  # target_dtype == numpy.float32 / numpy.float64:
+                else:  # target_dtype == np.float32 / np.float64:
                     return source.astype(target_dtype) / (1 << 31)
-            else:  # source_dtype == numpy.float32 / numpy.float64
-                M = numpy.max(numpy.abs(source))
+            else:  # source_dtype == np.float32 / np.float64
+                M = np.max(np.abs(source))
                 limit = 1 - 1e-16
                 if M > limit:
                     factor = limit / M
@@ -222,12 +227,12 @@ class Wave(Track):
                         f"applying scaling of {factor}"
                     )
                     source *= factor
-                if target_dtype == numpy.float32 or target_dtype == numpy.float64:
+                if target_dtype == np.float32 or target_dtype == np.float64:
                     return source.astype(target_dtype)
                 else:
-                    if target_dtype == numpy.int16:
+                    if target_dtype == np.int16:
                         return (source * (1 << 15)).astype(target_dtype)  # dither?
-                    else:  # target_dtype == numpy.int32
+                    else:  # target_dtype == np.int32
                         return (source * (1 << 31)).astype(target_dtype)  # dither?
 
     def convert_dtype(self, target_dtype):
@@ -260,51 +265,17 @@ class Wave(Track):
         except ValueError:
             try:
                 import soundfile as sf
-
-                value, fs = sf.read(path, dtype="int16")
             except ImportError:
-                logging.error(
-                    f"Scipy was unable to import {path}, "
-                    f"try installing soundfile python package for more compatability"
-                )
-                raise ImportError
-            except RuntimeError:
-                raise RuntimeError(f"Unable to import audio file {path}")
-        if value.ndim == 1:
-            if channel is not None and channel != 0:
-                raise MultiChannelError(
-                    f"cannot select channel {channel} from monaural file {path}"
-                )
-        if value.ndim == 2:
-            if channel is None:
-                raise MultiChannelError(
-                    f"must select channel when loading file {path} with {value.shape[1]} channels"
-                )
+                logger.error("Install soundfile for greater audio file compatability")
             try:
-                value = value[:, channel]
-            except IndexError:
-                raise MultiChannelError(
-                    f"cannot select channel {channel} from file "
-                    f"{path} with {value.shape[1]} channels"
-                )
+                value, fs = sf.read(path, dtype="int16")
+            except RuntimeError:
+                logger.error("Soundfile was unable to open file")
+                return None
+
+        if channel is not None:
+            value = value[:, channel]
         wav = Wave(value, fs, path=path)
-        if value.dtype == numpy.dtype(numpy.int16):
-            wav.min = -32767
-            wav.max = 32768
-        elif value.dtype == numpy.dtype(numpy.int32):
-            wav.min = -2147483648
-            wav.max = 2147483647
-        elif value.dtype == numpy.dtype(numpy.uint8):
-            wav.min = 0
-            wav.max = 255
-        elif value.dtype in set(
-            [numpy.dtype(numpy.float64), numpy.dtype(numpy.float32)]
-        ):
-            wav.max = 1.0
-            wav.min = -1.0
-        else:
-            logging.error(f"Wave dtype {value.dtype} not supported")
-            raise NotImplementedError
         return wav
 
     wav_read = read_wav
@@ -333,7 +304,7 @@ class Wave(Track):
     #     """wave1 + wave2"""
     #     if self.fs != other.fs:
     #         raise Exception("sampling frequency of waves must match")
-    #     return type(self)(numpy.concatenate((self.va, other.va)), self.fs)  # return correct (child) class
+    #     return type(self)(np.concatenate((self.va, other.va)), self.fs)  # return correct (child) class
 
     # def delete(self, a, b, fade = 0):
     #     pass
@@ -351,8 +322,8 @@ class Wave(Track):
     #         n = round(fade * self.fs)
     #         if n*2 > len(wave.signal):
     #             raise Exception("fade inverval is too large")
-    #         up = numpy.linspace(0, 1, n)
-    #         down = numpy.linspace(1, 0, n)
+    #         up = np.linspace(0, 1, n)
+    #         down = np.linspace(1, 0, n)
     #         p = wave.signal.copy()
     #         p[:n] *= up
     #         p[-n:] *= down
@@ -361,7 +332,7 @@ class Wave(Track):
     #         r = self.signal[a-n:]
     #         r[:n] *= up
     #     else:
-    #         self.signal = numpy.concatenate((self.signal[:a], wave.signal, self.signal[a:]))
+    #         self.signal = np.concatenate((self.signal[:a], wave.signal, self.signal[a:]))
 
     def crossfade(self, wave, length):
         """append wave to self, using a crossfade of a specified length in samples"""
@@ -371,12 +342,12 @@ class Wave(Track):
         assert length > 0
         assert wave.duration >= length
         assert self.duration >= length
-        ramp = numpy.linspace(1, 0, length + 2)[1:-1]  # don't include 0 and 1
+        ramp = np.linspace(1, 0, length + 2)[1:-1]  # don't include 0 and 1
         value = self.value.copy()
         value[-length:] = value[-length:] * ramp + wave.value[:length] * (
             1 - ramp
         )  # TODO: think about dtypes here
-        value = numpy.concatenate((value, wave.value[length:]))
+        value = np.concatenate((value, wave.value[length:]))
         return type(self)(value, self.fs)
 
     # TODO: Test / fix me!
@@ -385,8 +356,8 @@ class Wave(Track):
         logger.warning(
             "time_warping wave, most of the time this is not what is desired"
         )
-        time = numpy.arange(len(self._value))
+        time = np.arange(len(self._value))
         # time = index / self._fs
-        time = numpy.round(numpy.interp(time, x, y)).astype(numpy.int)
+        time = np.round(np.interp(time, x, y)).astype(np.int)
         # index = int(time * self.fs)
         self._value = self._value[time]

--- a/signalworks/tracking/wave.py
+++ b/signalworks/tracking/wave.py
@@ -26,6 +26,21 @@ class Wave(Track):
         offset: int = 0,
         path: Optional[Path] = None,
     ) -> None:
+        """Initializer for wave track object
+
+        Parameters
+        ----------
+        value : np.ndarray
+            orientation of array should be [samples, n_channels]
+        fs : int
+            sample rate of the signal
+        duration : Optional[int], optional
+            numer of samples in the signal, typically automatically calculated, by default None
+        offset : int, optional
+            initial offset of the signal, by default 0
+        path : Optional[Path], optional
+            underlying path for file referenced, by default None
+        """
         super().__init__(path)
 
         if path is None:


### PR DESCRIPTION
This merge requests adds  some docstrings, adds some customization to the spectrogram calculation (by allowing for pre-emphasis, and making the normalization of the signal be an optional parameter).

Furthermore, instead of manually specifying limits based on dtypes, I'm now using `np.iinfo` and `np.finfo` as needed.   For spectrogram clipping, i made use to `np.finfo.eps` so more data is preserved.