### PR TITLE
Fix collections warning

### DIFF
--- a/signalworks/tracking/timevalue.py
+++ b/signalworks/tracking/timevalue.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from collections import Iterable
+from collections.abc import Iterable
 
 import numpy
 from signalworks.tracking import Partition


### PR DESCRIPTION
`collections.Iterable` has been deprecated since Python 3.3, should now be `collections.abc.Iterable`