### PR TITLE
Fix s referenced before assignment

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.3.1
 commit = False
 tag = False
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 current_version = 0.3.0
-commit = True
-tag = True
+commit = False
+tag = False
 
 [bumpversion:file:setup.py]
 search = version="{current_version}"

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,6 @@ setup(
     setup_requires=["pytest-runner"],
     test_suite="tests",
     url="https://github.com/lxkain/signalworks",
-    version="0.3.0",
+    version="0.3.1",
     zip_safe=False,
 )

--- a/signalworks/__init__.py
+++ b/signalworks/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """Alexander Kain"""
 __email__ = "lxkain@gmail.com"
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/signalworks/dsp.py
+++ b/signalworks/dsp.py
@@ -264,20 +264,20 @@ def spectrogram_centered(
         Spectrogram matrix and a corresponding array of frequency values
     """
 
+    if normalize_signal:
+        s = wav.value / np.abs(np.max(wav.value))
+    else:
+        s = wav.value.astype(float)
+
     # When dealing with multi-channel audio
     if wav.value.ndim > 1:
         # if an aggregation method is provided, use that to squash data together
         if channel_aggregate is not None:
-            s = channel_aggregate(wav.value, axis=0).astype(float)  # type: ignore
+            s = channel_aggregate(s, axis=0)  # type: ignore
 
         # if no aggregation method is provided, and no channel is provided, grab the first channel
         else:
-            s = wav.value[:, channel].astype(float)
-
-    if normalize_signal:
-        s = wav.value / np.abs(
-            np.max(wav.value)
-        )  # make float by normalizing and later clipping is more uniform
+            s = s[:, channel]
 
     if pre_emphasis is not None:
         s -= pre_emphasis * np.roll(s, -1)


### PR DESCRIPTION
spectrogram_centered would reference `s` before assignment if the Wave object was single channel, and `normalize_signal` was set to false.  This fixes that issue.