### PR TITLE
Make wave.value 2 d

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.1
+current_version = 0.3.2
 commit = False
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,6 @@ setup(
     setup_requires=["pytest-runner"],
     test_suite="tests",
     url="https://github.com/lxkain/signalworks",
-    version="0.3.1",
+    version="0.3.2",
     zip_safe=False,
 )

--- a/signalworks/__init__.py
+++ b/signalworks/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """Alexander Kain"""
 __email__ = "lxkain@gmail.com"
-__version__ = "0.3.1"
+__version__ = "0.3.2"


### PR DESCRIPTION
PR primarily forces wave.value to be a 2D array.  There is extra support for handling proper dtype importing via `soundfile` as well.

Also bumping version on pypi.